### PR TITLE
Fixed market orders

### DIFF
--- a/src/Api/Support/PendingOrder.php
+++ b/src/Api/Support/PendingOrder.php
@@ -33,6 +33,7 @@ class PendingOrder extends PendingRequest
     {
         $this->attributes['type'] = self::TYPE_MARKET;
         $this->attributes['size'] = $size;
+        $this->attributes['price'] = null;
         
         return $this;
     }

--- a/tests/Api/OrdersTest.php
+++ b/tests/Api/OrdersTest.php
@@ -118,7 +118,7 @@ class OrdersTest extends TestCase
         $this->assertEquals('BTC-PERP', $order->market);
         $this->assertEquals(99.9, $order->size);
         $this->assertEquals(
-            ['market' => 'BTC-PERP', 'size' => 99.9, 'type' => 'market', 'side' => 'sell', 'ioc' => true],
+            ['market' => 'BTC-PERP', 'size' => 99.9, 'type' => 'market', 'side' => 'sell', 'ioc' => true, 'price' => null],
             $order->toArray()
         );
 
@@ -138,7 +138,7 @@ class OrdersTest extends TestCase
         $this->assertEquals('BTC-PERP', $order->market);
         $this->assertEquals(10, $order->size);
         $this->assertEquals(
-            ['market' => 'BTC-PERP', 'size' => 10, 'type' => 'market', 'side' => 'buy', 'reduceOnly' => true, 'clientId' => 'foo'],
+            ['market' => 'BTC-PERP', 'size' => 10, 'type' => 'market', 'side' => 'buy', 'reduceOnly' => true, 'clientId' => 'foo', 'price' => null],
             $order->toArray()
         );
     }


### PR DESCRIPTION
The FTX API requires us to set price to null for market orders.
If the price key is not included, the order is rejected: `{"success":false,"error":"Missing parameter price"}`

See https://docs.ftx.com/#place-order