### PR TITLE
allows for use with guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/http-message": "^1.0",
         "php-http/httplug": "^2.0",
         "php-http/discovery": "^1.0",
-        "php-http/client-implementation": "^1.0",
+        "psr/http-client-implementation": "^1.0",
         "php-http/client-common": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
I couldn't satisfy the requirements with my Laravel project even though I had the guzzlehttp/guzzle HTTP client library installed.

The psr/http-client-implementation allows [the following packages](https://packagist.org/providers/psr/http-client-implementation).


Best regards