### PR TITLE
Added support for getting the global lending history

### DIFF
--- a/src/Api/SpotMargin.php
+++ b/src/Api/SpotMargin.php
@@ -4,8 +4,12 @@
 namespace FTX\Api;
 
 
+use FTX\Api\Traits\TransformsTimestamps;
+
 class SpotMargin extends HttpApi
 {
+    use TransformsTimestamps;
+
     const SPOTMARGIN_URI = 'spot_margin';
 
     public function borrowRates()
@@ -37,7 +41,13 @@ class SpotMargin extends HttpApi
     {
         return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/lending_history'));
     }
-    
+
+    public function globalLendingHistory(?\DateTimeInterface $start_time = null, ?\DateTimeInterface $end_time = null)
+    {
+        [$start_time, $end_time] = $this->transformTimestamps($start_time, $end_time);
+        return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/history', compact('start_time', 'end_time')));
+    }
+
     public function offers()
     {
         return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/offers'));

--- a/src/Api/SpotMargin.php
+++ b/src/Api/SpotMargin.php
@@ -42,10 +42,10 @@ class SpotMargin extends HttpApi
         return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/lending_history'));
     }
 
-    public function globalLendingHistory(?\DateTimeInterface $start_time = null, ?\DateTimeInterface $end_time = null)
+    public function globalLendingHistory(?string $coin = null, ?\DateTimeInterface $start_time = null, ?\DateTimeInterface $end_time = null)
     {
         [$start_time, $end_time] = $this->transformTimestamps($start_time, $end_time);
-        return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/history', compact('start_time', 'end_time')));
+        return $this->respond($this->http->get(self::SPOTMARGIN_URI.'/history', compact('coin', 'start_time', 'end_time')));
     }
 
     public function offers()

--- a/tests/Api/SpotMarginTest.php
+++ b/tests/Api/SpotMarginTest.php
@@ -65,6 +65,28 @@ class SpotMarginTest extends TestCase
         $this->assertEquals($this->client->getLastRequest()->getMethod(), 'GET');
     }
 
+    public function testGlobalLendingHistory()
+    {
+        $this->spotMargin->globalLendingHistory();
+
+        $this->assertEquals('/api/spot_margin/history', $this->client->getLastRequest()->getUri()->getPath());
+        $this->assertEquals('GET', $this->client->getLastRequest()->getMethod());
+        $this->assertEquals('', $this->client->getLastRequest()->getUri()->getQuery());
+
+        $start = new \DateTime('2020-02-01');
+        $end = new \DateTime('2020-03-01');
+        $this->spotMargin->globalLendingHistory($start, $end);
+
+        $this->assertEquals('/api/spot_margin/history', $this->client->getLastRequest()->getUri()->getPath());
+        $this->assertEquals('GET', $this->client->getLastRequest()->getMethod());
+
+        parse_str($this->client->getLastRequest()->getUri()->getQuery(), $query);
+
+        $this->assertEquals(['start_time' => $start->getTimestamp(), 'end_time' => $end->getTimestamp()],
+            $query
+        );
+    }
+
     public function testOffers()
     {
         $this->spotMargin->offers();

--- a/tests/Api/SpotMarginTest.php
+++ b/tests/Api/SpotMarginTest.php
@@ -73,9 +73,10 @@ class SpotMarginTest extends TestCase
         $this->assertEquals('GET', $this->client->getLastRequest()->getMethod());
         $this->assertEquals('', $this->client->getLastRequest()->getUri()->getQuery());
 
+
         $start = new \DateTime('2020-02-01');
         $end = new \DateTime('2020-03-01');
-        $this->spotMargin->globalLendingHistory($start, $end);
+        $this->spotMargin->globalLendingHistory(null, $start, $end);
 
         $this->assertEquals('/api/spot_margin/history', $this->client->getLastRequest()->getUri()->getPath());
         $this->assertEquals('GET', $this->client->getLastRequest()->getMethod());
@@ -83,6 +84,19 @@ class SpotMarginTest extends TestCase
         parse_str($this->client->getLastRequest()->getUri()->getQuery(), $query);
 
         $this->assertEquals(['start_time' => $start->getTimestamp(), 'end_time' => $end->getTimestamp()],
+            $query
+        ); 
+
+
+        $coin = 'USD';
+        $this->spotMargin->globalLendingHistory($coin, $start, $end);
+
+        $this->assertEquals('/api/spot_margin/history', $this->client->getLastRequest()->getUri()->getPath());
+        $this->assertEquals('GET', $this->client->getLastRequest()->getMethod());
+
+        parse_str($this->client->getLastRequest()->getUri()->getQuery(), $query);
+
+        $this->assertEquals(['coin' => $coin, 'start_time' => $start->getTimestamp(), 'end_time' => $end->getTimestamp()],
             $query
         );
     }


### PR DESCRIPTION
API doc: https://docs.ftx.com/#get-lending-history

Ideally this would be named `lendingHistory()` and the existing `lendingHistory()` would get renamed to `myLendingHistory()` or `ownLendingHistory()`, but that would break BC so it's probably not worth it.