### PR TITLE
Fixed the TransformsTimestamps trait to handle DateTimeImmutable

### DIFF
--- a/src/Api/Traits/TransformsTimestamps.php
+++ b/src/Api/Traits/TransformsTimestamps.php
@@ -9,7 +9,7 @@ trait TransformsTimestamps
     protected function transformTimestamps(...$timestamps)
     {
         return array_map(function($dateTime) {
-            if($dateTime instanceof \DateTime) {
+            if($dateTime instanceof \DateTimeInterface) {
                 return $dateTime->getTimestamp();
             }
             return null;

--- a/tests/Api/MarketsTest.php
+++ b/tests/Api/MarketsTest.php
@@ -63,4 +63,11 @@ class MarketsTest extends TestCase
         $this->markets->trades('BTC-PERP', null, $start, $end);
         $this->assertEquals($this->client->getLastRequest()->getUri()->getQuery(), 'start_time='.$start->getTimestamp().'&end_time='.$end->getTimestamp());
     }
+
+    public function testDateTimeImmutable()
+    {
+        $start = new \DateTimeImmutable('2020-02-01');
+        $this->markets->trades('BTC-PERP', null, $start);
+        $this->assertEquals($this->client->getLastRequest()->getUri()->getQuery(), 'start_time='.$start->getTimestamp());
+    }
 }


### PR DESCRIPTION
The timestamp parameters for the various api methods are of type DateTimeInterface, however the TransformsTimestamps trait was checking for exactly DateTime. This means that other types implementing the interface (such as DateTimeImmutable) would be ignored.

Added a test case, which fails before the fix but now passes.